### PR TITLE
Fixes typo in the project URL

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     long_description=long_description,
 
     # The project's main homepage.
-    url='https://github.com/alistairew/pyroc',
+    url='https://github.com/alistairewj/pyroc',
 
     # Author details
     author='Alistair Johnson, Lucas Bulgarelli',


### PR DESCRIPTION
Fixes small typo in the project URL (listed as the project homepage at https://pypi.org/project/pyroc/)